### PR TITLE
Filter empty rows when looking for the header in `findHeader`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "http://1clickBOM.com",
   "author": "Kaspar Emanuel",
   "license": "MIT",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "scripts": {
     "test": "istanbul cover -x test/ --include-all-sources _mocha",
     "format": "prettier --write src/*.js test/*.js"

--- a/src/parser.js
+++ b/src/parser.js
@@ -327,11 +327,11 @@ function processLine(warnings, line, i) {
   return newLine
 }
 
-// finds the first row with the most columns
+// finds the first row with the most columns and least empty cells
 function findHeader(aoa) {
   const {i} = aoa.reduce(
     (prev, row, i) => {
-      const len = row.length
+      const len = row.filter(cell => cell != null).length
       if (prev.len < len) {
         return {i, len}
       }


### PR DESCRIPTION
Fixes #16